### PR TITLE
rubocop: Depend on rubocop-minitest as well

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -3,6 +3,7 @@ require:
   - rubocop-performance
   - rubocop-rake
   - rubocop-rspec
+  - rubocop-minitest
 
 AllCops:
   NewCops: enable

--- a/voxpupuli-rubocop.gemspec
+++ b/voxpupuli-rubocop.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'rake', '~> 13.0', '>= 13.0.6'
   s.add_runtime_dependency 'rubocop', '~> 1.50.0'
+  s.add_runtime_dependency 'rubocop-minitest', '~> 0.30.0'
   s.add_runtime_dependency 'rubocop-performance', '~> 1.17.0'
   s.add_runtime_dependency 'rubocop-rake', '~> 0.6.0'
   s.add_runtime_dependency 'rubocop-rspec', '~> 2.20.0'


### PR DESCRIPTION
Many of our gems require rubocop-minitest. It makes sense that our meta gem voxpupuli-rubocop pulls it in.