### PR TITLE
Enforce require_parentheses_when_complex style for ternaries

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -23,6 +23,9 @@ Gemspec/RequireMFA:
 Gemspec/DevelopmentDependencies:
   Enabled: false
 
+Style/TernaryParentheses:
+  EnforcedStyle: require_parentheses_when_complex
+
 Style/TrailingCommaInHashLiteral:
   Enabled: True
   EnforcedStyleForMultiline: consistent_comma


### PR DESCRIPTION
From the cops documentation for the good style:

```ruby
foo = bar? ? a : b
foo = bar.baz? ? a : b
foo = (bar && baz) ? a : b
```