### PR TITLE
rubocop.yml: exclude fixtures directory

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -14,6 +14,7 @@ AllCops:
   Exclude:
     - vendor/**/*
     - .vendor/**/*
+    - spec/fixtures/**/*
 
 # this currently doesn't work with the way we handle our secrets
 Gemspec/RequireMFA:


### PR DESCRIPTION
When we've a fixtures directory we should not lint the fixtures. Those are usually files that we us in our tests to compare output of certain things.