### PR TITLE
RSpec/MultipleExpectations: Disable the cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -41,3 +41,6 @@ Style/TrailingCommaInArguments:
 
 Metrics:
   Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false


### PR DESCRIPTION
We always violate it and disable it in the individual gems anyways.