### PR TITLE
Require Ruby 3.2+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Install Ruby 3.1
+      - name: Install Ruby 3.2
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
       - name: Run Rubocop
         run: bundle exec rake rubocop

--- a/README.md
+++ b/README.md
@@ -65,16 +65,17 @@ a "RuboCop ToDo file", which is basically an allow-list of all current
 violations:
 
 ```
-bundle exec rubocop --regenerate-todo
+bundle exec rubocop --regenerate-todo --no-auto-gen-timestamp
 ```
 
 ## New major releases
 
-As described above, we will do new minor releases of voxpupuli-rubocop with
-newer RuboCop dependencies. We also ship a rubocop.yml that people can use. This
-file currently configures Ruby 3.1 as a target version. This will be adjusted in
-major releases.
+As described above, we will do new minor releases of voxpupuli-rubocop with newer RuboCop dependencies.
+We also ship a rubocop.yml that people can use.
+This file currently configures Ruby 3.2 as a target version.
+This will be adjusted in major releases.
 
+The 4.x releases configured Ruby 3.1.
 The 3.x releases configured Ruby 2.7.
 
 User of voxpupuli-rubocop don't have to use our rubocop.yml, they can just rely

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
   DisplayCopNames: true
   ExtraDetails: true
   DisplayStyleGuide: true
-  TargetRubyVersion: '3.1'
+  TargetRubyVersion: '3.2'
   Exclude:
     - vendor/**/*
     - .vendor/**/*

--- a/voxpupuli-rubocop.gemspec
+++ b/voxpupuli-rubocop.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.licenses    = 'Apache-2.0'
   s.files       = Dir['lib/**/*.rb'] + ['rubocop.yml']
 
-  s.required_ruby_version = '>= 3.1.0'
+  s.required_ruby_version = '>= 3.2.0'
 
   s.add_dependency 'rake', '~> 13.0', '>= 13.0.6'
   s.add_dependency 'rubocop', '~> 1.81.1'


### PR DESCRIPTION
This is the new Ruby version we require in all new gem releases since some months, so we can require it here.